### PR TITLE
Return Static Assets in Production

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,55 +1,83 @@
+// Package Dependencies
 const bodyParser = require('body-parser');
 const express = require('express');
-
 const helmet = require('helmet');
-const mongoose = require('mongoose');  // using ODM wrapper for MongoDB
-const config = require('./config');
-const morgan = require('morgan');  // log requests to the console
+const mongoose = require('mongoose');
+const morgan = require('morgan');
 
+// Local Dependencies
+const { DB_URL, NODE_ENV: ENV } = require('./config');
+
+// Instatiate Express Server
 const app = express();
-app.use(helmet());
 
-// set up MongoDB connection using the global promise library and then get connection
-mongoose.connect(config.DB_URL, {promiseLibrary: global.Promise}, error => {
-  if (error) {
-    console.log(`MongoDB connection error: ${error}`);
-    process.exit(1);  // should consider alternative to exiting the app due to db conn issue
-  }
+/**
+ * MONGODB CONNECTION
+ */
+
+// Setup MongoDB connection using the global promise library and then get connection
+mongoose.connect(DB_URL, { promiseLibrary: global.Promise }, error => {
+	if (error) {
+		console.log(`MongoDB connection error: ${error}`);
+
+		// should consider alternative to exiting the app due to db conn issue
+		process.exit(1);
+	}
 });
+
 const db = mongoose.connection;
 
-// To allow access on headers and also to avoid CORS issues
+/**
+ * MIDDLEWARE
+ */
+
+// Set security-related HTTP headers (https://expressjs.com/en/advanced/best-practice-security.html#use-helmet)
+app.use(helmet());
+
+// Allow access on headers and avoid CORS issues
 app.use((req, res, next) => {
-  res.header('Access-Control-Allow-Origin', '*');
-  res.header(
-    'Access-Control-Allow-Headers',
-    'Origin, X-Requested-With, Content-Type, Access, Authorization',
-  );
+	res.header('Access-Control-Allow-Origin', '*');
+	res.header(
+		'Access-Control-Allow-Headers',
+		'Origin, X-Requested-With, Content-Type, Access, Authorization'
+	);
 
-  if (req.method === 'OPTIONS') {
-    res.header('Access-Control-Allow-Methods', 'GET, PUT, POST, PATCH, DELETE');
+	if (req.method === 'OPTIONS') {
+		res.header('Access-Control-Allow-Methods', 'GET, PUT, POST, PATCH, DELETE');
 
-    return res.status(200).json({});
-  }
+		return res.status(200).json({});
+	}
 
-  next();
+	next();
 });
 
 // Parse incoming requests
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
-app.use(morgan('dev'));  // log every request to the console
 
-// Routes
-/*
-  TODO:
-  Update application routes
-*/
-app.get('/', (req, res) => {
-  res.status(200).send('Hello, World!');
-});
+// Log every request to the console
+app.use(morgan('dev'));
+
+/**
+ * ROUTES
+ */
 
 // API Routes
 app.use('/api', require('./routes/api'));
+
+// TODO: Create additional routes as necessary
+
+// Serve static assets and index.html in production
+if (ENV === 'production') {
+	// Serve static assets
+	app.use(express.static('client/build'));
+
+	// Serve index.html file if not other routes were matched
+	const { resolve } = require('path');
+
+	app.get('**', (req, res) => {
+		res.sendFile(resolve(__dirname, 'client', 'build', 'index.html'));
+	});
+}
 
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ const morgan = require('morgan');
 // Local Dependencies
 const { DB_URL, NODE_ENV: ENV } = require('./config');
 
-// Instatiate Express Server
+// Instantiate Express Server
 const app = express();
 
 /**
@@ -72,7 +72,7 @@ if (ENV === 'production') {
 	// Serve static assets
 	app.use(express.static('client/build'));
 
-	// Serve index.html file if not other routes were matched
+	// Serve index.html file if no other routes were matched
 	const { resolve } = require('path');
 
 	app.get('**', (req, res) => {

--- a/app.js
+++ b/app.js
@@ -17,12 +17,12 @@ const app = express();
 
 // Setup MongoDB connection using the global promise library and then get connection
 mongoose.connect(DB_URL, { promiseLibrary: global.Promise }, error => {
-	if (error) {
-		console.log(`MongoDB connection error: ${error}`);
+  if (error) {
+    console.log(`MongoDB connection error: ${error}`);
 
-		// should consider alternative to exiting the app due to db conn issue
-		process.exit(1);
-	}
+    // should consider alternative to exiting the app due to db conn issue
+    process.exit(1);
+  }
 });
 
 const db = mongoose.connection;
@@ -36,19 +36,19 @@ app.use(helmet());
 
 // Allow access on headers and avoid CORS issues
 app.use((req, res, next) => {
-	res.header('Access-Control-Allow-Origin', '*');
-	res.header(
-		'Access-Control-Allow-Headers',
-		'Origin, X-Requested-With, Content-Type, Access, Authorization'
-	);
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header(
+    'Access-Control-Allow-Headers',
+    'Origin, X-Requested-With, Content-Type, Access, Authorization'
+  );
 
-	if (req.method === 'OPTIONS') {
-		res.header('Access-Control-Allow-Methods', 'GET, PUT, POST, PATCH, DELETE');
+  if (req.method === 'OPTIONS') {
+    res.header('Access-Control-Allow-Methods', 'GET, PUT, POST, PATCH, DELETE');
 
-		return res.status(200).json({});
-	}
+    return res.status(200).json({});
+  }
 
-	next();
+  next();
 });
 
 // Parse incoming requests
@@ -69,15 +69,15 @@ app.use('/api', require('./routes/api'));
 
 // Serve static assets and index.html in production
 if (ENV === 'production') {
-	// Serve static assets
-	app.use(express.static('client/build'));
+  // Serve static assets
+  app.use(express.static('client/build'));
 
-	// Serve index.html file if no other routes were matched
-	const { resolve } = require('path');
+  // Serve index.html file if no other routes were matched
+  const { resolve } = require('path');
 
-	app.get('**', (req, res) => {
-		res.sendFile(resolve(__dirname, 'client', 'build', 'index.html'));
-	});
+  app.get('**', (req, res) => {
+    res.sendFile(resolve(__dirname, 'client', 'build', 'index.html'));
+  });
 }
 
 module.exports = app;


### PR DESCRIPTION
## Issue Number:

Resolves #31

## Issue Description:

When in production, serve static assets from `client/build` and respond with `index.html` for unmatched routes.

### Summary of solution:

1. Cleaned up app.js
2. Added check at the end of the file for production
3. Serving static files from client/build
4. Responding with client/build/index.html for all unmatched routes

### Can this issue be closed?

Yes

### Should any new issues be added as a result of this solution?

Possibly look into server-side Preact component rendering with preact-render-to-string.