### PR TITLE
update package.json to use NODE_PATH=. and add engines key

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
   "description": "Open source project for Grow with Google Udacity Scholarship Challenge - Navigation app using offline first strategy and google maps api",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js",
+    "start": "NODE_PATH=. node server.js",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
     "client": "npm run start --prefix client",
-    "server": "nodemon server.js",
-    "test": "NODE_ENV=test mocha tests -r chai/register-expect",
+    "server": "NODE_PATH=. nodemon server.js",
+    "test": "NODE_PATH=. NODE_ENV=test mocha tests -r chai/register-expect",
     "test-watch": "nodemon --exec 'npm test'"
+  },
+  "engines": {
+    "node": "8.9.4",
+    "npm": "5.6.0"
   },
   "repository": {
     "type": "git",

--- a/tests/apiRoutes.js
+++ b/tests/apiRoutes.js
@@ -1,7 +1,7 @@
 // api routes tests
 const request = require('supertest');
 
-const app = require('../app');
+const app = require('app');
 
 describe('API Routes', () => {
   describe('GET /api/users/current', () => {


### PR DESCRIPTION
## Issue Number:
#46

## Issue Description:
**feature**
1. Set the `"engines"` key in package.json to be clear what version of Node this project works with. Also used for hosting on sites like Heroku.

2. Set the `NODE_PATH` to `.` to prevent having to go back up many directories i.e. `../../../app` becomes `app` It still allows for relative paths so it's not a breaking change.

### Summary of solution:
1. Add `"engines"` key in package.json with the latest LTS Node and npm versions.
2. Change the scripts to set `NODE_PATH` to `.` 
3. Update the `require` in `tests/apiRoutes` to make sure it works.

### Can this issue be closed?
Yes

### Should any new issues be added as a result of this solution?
No

### Have you named your branch in a descriptive way? Remember to name your branch in a unique and descriptive manner in order to properly reflect the issue or feature.
Somewhat

### Thanks for contributing!
