### PR TITLE
feat: Add staticmap endpoint

### DIFF
--- a/controllers/google-api-controller.js
+++ b/controllers/google-api-controller.js
@@ -1,5 +1,7 @@
 const http = require('https');
+const { URL } = require('url');
 const { GOOGLE_API_KEY } = require('../config');
+const { convertToQueryString } = require('./utils-controller');
 
 /**
  * Geolocation API access
@@ -32,11 +34,70 @@ exports.getGeolocation = (appReq, appRes) => {
 
     res.on('end', () => {
       const body = Buffer.concat(chunks);
-      console.log(body.toString());
       appRes.send(JSON.parse(body.toString()));
     });
   });
 
   req.write(JSON.stringify({}));
   req.end();
+};
+
+/**
+ * Static Maps API
+ * Returns an image (either GIF, PNG, or JPEG) in response to URL request.
+ * For each request, you can specifiy the location, size, zoom level, type of
+ * map, and placement of optional markers at locations on the map; including
+ * labels.
+ *
+ * API URL must be of the following form:
+ * https://maps.googleapis.com/maps/api/staticmap?parameters
+ */
+
+/**
+ * @description Handles request to get static map via google api
+ *
+ * @param {number} appReq.body.centerLat - lattitude for map center
+ * @param {number} appReq.body.centerLng - longitude for map center
+ * @param {number} appReq.body.zoom - resolution of the current view [0 - 21+], default 15
+ * @param {string} appReq.body.size - size of image to return in pixels, default 640x640
+ * @param {string} appReq.body.scale - image size multiplier[1, 2], default 1
+ * @param {string} appReq.body.maptype - map format: [roadmap, satellite, terrain, hybrid],
+ *   default is roadmap
+ * @param {string} appReq.body.markers - map pin for given location, default sets it
+ *   to center of the map (https://developers.google.com/maps/documentation/static-maps/intro#Markers)
+ * @param {string} appReq.body.format - image type [png8, png32, gif, jpg, jpg-baseline],
+ *   default is png8
+ *
+ * @returns {binary} Image file in the requested format
+ */
+exports.getStaticMap = (appReq, appRes) => {
+  const BASE_URL = 'https://maps.googleapis.com/maps/api/staticmap?';
+  const params = {
+    key: GOOGLE_API_KEY,
+    center: `${appReq.body.centerLat},${appReq.body.centerLng}`,
+    zoom: appReq.body.zoom || 15,
+    size: appReq.body.size || '640x640',
+    scale: appReq.body.scale || 1,
+    maptype: appReq.body.maptype || 'roadmap',
+    markers: appReq.body.markers || `${appReq.body.lat},${appReq.body.lng}`,
+    format: appReq.body.format || 'png8',
+  };
+  const queryString = convertToQueryString(params);
+  const reqUrl = new URL(`${BASE_URL}${queryString}`);
+
+  http.get(reqUrl, (res) => {
+    const chunks = [];
+
+    res.on('data', (chunk) => {
+      chunks.push(chunk);
+    });
+
+    res.on('end', () => {
+      const body = Buffer.concat(chunks);
+      appRes.type('png');
+      appRes.send(body);
+    });
+  }).on('error', (e) => {
+    appRes.send(e);
+  });
 };

--- a/controllers/utils-controller.js
+++ b/controllers/utils-controller.js
@@ -39,3 +39,19 @@ exports.verifyToken = (req, res, next) => {
     next();
   });
 };
+
+/**
+ * @description Utility function for generating query string from an object with
+ *   key-value pairs for params needed for http request using native node https.
+ *
+ * @param {Object} key-value pairs for params needed for request to be parsed as
+ *   query string
+ */
+exports.convertToQueryString = (paramsObject) => {
+  const str = [];
+  const keys = Object.keys(paramsObject);
+  keys.forEach((element) => {
+    str.push(`${encodeURIComponent(element)}=${encodeURIComponent(paramsObject[element])}`);
+  });
+  return str.join('&');
+};

--- a/routes/map.js
+++ b/routes/map.js
@@ -14,7 +14,7 @@ router.get('/', (req, res) => {
   res.send('NOT IMPLEMENTED: Map View');
 });
 
-// Geolocation api hook
 router.get('/geolocation', googleApiController.getGeolocation);
+router.post('/staticmap', googleApiController.getStaticMap);
 
 module.exports = router;


### PR DESCRIPTION
## Issue Number:
#60 
## Issue Description:
Add map/staticmap endpoint that returns static map via google api call.

### Summary of solution:
1. Add "/staticmap" endpoint to map route
2. Add `getStaticMap` controller function for making google map api call
3. Add utility function for generating query string from an object representation of params

### Can this issue be closed?
No, not yet
### Should any new issues be added as a result of this solution?
Needs unit test issue - verified via Postman
### Have you named your branch in a descriptive way? Remember to name your branch in a unique and descriptive manner in order to properly reflect the issue or feature.

### Thanks for contributing!
