### PR TITLE
fix: Remove hard coded format

### DIFF
--- a/controllers/google-api-controller.js
+++ b/controllers/google-api-controller.js
@@ -94,7 +94,7 @@ exports.getStaticMap = (appReq, appRes) => {
 
     res.on('end', () => {
       const body = Buffer.concat(chunks);
-      appRes.type('png');
+      appRes.type(params.format.substr(0, 3)); // [png, gif, or jpg]
       appRes.send(body);
     });
   }).on('error', (e) => {


### PR DESCRIPTION
## Issue Number:
enhancement to #88 
## Issue Description:
Minor modification to ensure proper request type is returned, currently hardcoded to 'png' 

### Summary of solution:
1. Pass the first 3 characters of the image format type was requested

### Can this issue be closed?
No
### Should any new issues be added as a result of this solution?
No
### Have you named your branch in a descriptive way? Remember to name your branch in a unique and descriptive manner in order to properly reflect the issue or feature.

### Thanks for contributing!
