### PR TITLE
Small tweak: now places load as soon as you open places tab

### DIFF
--- a/client/src/components/PlacesMap/index.js
+++ b/client/src/components/PlacesMap/index.js
@@ -87,26 +87,32 @@ class PlacesContainer extends Component {
       />
     );
 
+    const {lat} = this.state;
+
     return (
-      <Map
-        google={this.props.google}
-        zoom={14}
-        center={{
-          lat: this.state.lat,
-          lng: this.state.lng,
-        }}
-        onClick={this.fetchPlaces}
-      >
-        {markers}
-        <InfoWindow
-          marker={this.state.activeMarker}
-          visible={this.state.showingInfoWindow}
-          >
-          <h1>
-            {this.state.selectedPlace.name}
-          </h1>
-        </InfoWindow>
-      </Map>
+      <div>
+        {lat &&
+        <Map
+          google={this.props.google}
+          zoom={14}
+          center={{
+            lat: this.state.lat,
+            lng: this.state.lng,
+          }}
+          onReady={this.fetchPlaces}
+        >
+          {markers}
+          <InfoWindow
+            marker={this.state.activeMarker}
+            visible={this.state.showingInfoWindow}
+            >
+            <h1>
+              {this.state.selectedPlace.name}
+            </h1>
+          </InfoWindow>
+        </Map>}
+      </div>
+      
     );
   }
 }


### PR DESCRIPTION
**## Issue Number:**
#132 

**## Issue Description:**
Places loaded only after clicking on the map and not as soon as navigating to the /places Component.

**### Summary of solution:**
1. Check if lat is available when rendering the component.
2. Put the Map Component insider a new div and render it only when lat is available.
3. 

**### Can this issue be closed?**
No, other issues inside #132 need to be worked on.

**### Should any new issues be added as a result of this solution?**
Nope.

**### Have you named your branch in a descriptive way? Remember to name your branch in a unique and descriptive manner in order to properly reflect the issue or feature.**
Yes!

### Thanks for contributing!
