### PR TITLE
feat: Add autocomplete and places query end points

### DIFF
--- a/controllers/utils-controller.js
+++ b/controllers/utils-controller.js
@@ -44,8 +44,8 @@ exports.verifyToken = (req, res, next) => {
  * @description Utility function for generating query string from an object with
  *   key-value pairs for params needed for http request using native node https.
  *
- * @param {Object} key-value pairs for params needed for request to be parsed as
- *   query string
+ * @param {Object} paramsObject: key-value pairs for params needed for request
+ *   to be parsed as query string
  */
 exports.convertToQueryString = (paramsObject) => {
   const str = [];
@@ -54,4 +54,28 @@ exports.convertToQueryString = (paramsObject) => {
     str.push(`${encodeURIComponent(element)}=${encodeURIComponent(paramsObject[element])}`);
   });
   return str.join('&');
+};
+
+/**
+ * @description Utility function for processing google places autocomplete
+ *   results.
+ * 
+ * @param {Object} queryResult: JSON response containing two root elememts:
+ *   - status: contains metadata on the request along with status codes
+ *   - predictions: an array of query predictions
+ * 
+ * @returns {[Ojbect]} An array of suggestions as object with two root elements:
+ *   - prediction: the predicted query
+ *   - placeID: if prediction is a place else ''
+ */
+exports.processAutocomplete = (queryResult) => {
+  const suggestions = [];
+  queryResult.predictions.forEach((result) => {
+    const description = result.description;
+    const placeId = result.place_id || '';
+    suggestions.push({
+      description, placeId,
+    });
+  });
+  return suggestions;
 };

--- a/routes/search.js
+++ b/routes/search.js
@@ -1,5 +1,4 @@
 const express = require('express');
-
 const router = express.Router();
 
 // require controller modules
@@ -7,8 +6,7 @@ const savedDirectionsController = require('../controllers/saved-directions-contr
 const savedPinsController = require('../controllers/saved-pins-controller');
 const searchHistoryController = require('../controllers/search-history-controller');
 const { verifyToken } = require('../controllers/utils-controller');
-/* TODO - require specific functions needed for search from google-api-controller */
-const { autocomplete } = require('../controllers/google-api-controller');
+const { autocomplete, placeDetails } = require('../controllers/google-api-controller');
 
 /**
  * @description Handle requests to search main end point
@@ -32,8 +30,11 @@ router.post('/savedpins', verifyToken, savedPinsController.postSavedPins);
 router.delete('/savedpins', verifyToken, savedPinsController.deleteSavedPins);
 router.delete('/savedpins/:id', verifyToken, savedPinsController.deleteSavedPinsById);
 
-// TODO - delete: will most likely do search autocomplete from frontend
-// router.post('/autocomplete', autocomplete);
+/**
+ * Search and Places query endpoints
+ */
+router.get('/places/:id', placeDetails);
+router.post('/autocomplete', autocomplete);
 
 /**
  * Saved search history end points


### PR DESCRIPTION
## Issue Number:
#145 
## Issue Description:
Setup backend suport for search query autocomplete and place details via
google places api.

### Summary of solution:
1. Add {POST} /search/autocomplete end point for autocompleting user query
2. Add {GET} /search/places/:id end point for getting place details for given google place id
3. Add utility function for processing before sending server response

### Can this issue be closed?
no - WIP: working towards refactoring frontend search per remaining tasks in #145 
### Should any new issues be added as a result of this solution?
no
### Have you named your branch in a descriptive way? Remember to name your branch in a unique and descriptive manner in order to properly reflect the issue or feature.

### Thanks for contributing!
