### PR TITLE
Search Feature: Update map on prediction selection

### DIFF
--- a/client/src/components/Search/index.js
+++ b/client/src/components/Search/index.js
@@ -3,7 +3,7 @@ import style from './style';
 import axios from 'axios';
 import {API_SERVER} from '../../../config';
 const OK_Status = 'OK';
-
+let marker;
 export default class Search extends Component {
   constructor(props) {
     super(props);
@@ -44,12 +44,11 @@ export default class Search extends Component {
       }).then((response) => { 
         if(response.data.status == OK_Status)
         {
-          let [searchResult] = response.data.results;
+          const [searchResult] = response.data.results;
           this.onPlaceFound(searchResult);
         }          
         else
-          alert(response.data.status);
-      
+          alert(response.data.status);      
       });
       
   }
@@ -59,21 +58,19 @@ export default class Search extends Component {
    *
    * @param {*} placeDetail 
    */
+  
   onPlaceFound(placeDetail) {
     this.props.map.setZoom(16);
     const location = placeDetail.geometry.location;
-    const userMarker = L.marker(location).addTo(this.props.map)
+    
+    if (marker) 
+      this.props.map.removeLayer(marker); 
+    
+    marker = L.marker(location).addTo(this.props.map)
     .bindPopup(`<b>${placeDetail.name} </b>${placeDetail.formatted_address}`);
     this.props.map.setView(location, 16);
-    //ToDO : add to state , this location should be separate to user location
+    //ToDO : add to parent state , this location should be separate to user location
     
-    }
-
-  handleSelection(data,event) {
-    // TODO - hookup to map instance and add marker for given location
-    //      - get geolocation details based on prediction
-    console.log(data);
-
     }
 
   render() {
@@ -81,7 +78,7 @@ export default class Search extends Component {
     const childWithProps = this.props.children.map((child) => {
       return cloneElement(child, {
         predictions: this.state.predictions,
-        onClicked: this.handleSelection
+        onClicked: this.onPlaceFound
       });
     });
     

--- a/client/src/components/SearchResults/index.js
+++ b/client/src/components/SearchResults/index.js
@@ -2,7 +2,7 @@ import { h, Component } from 'preact';
 import style from './style.css';
 import axios from 'axios';
 import {API_SERVER} from '../../../config';
-const OK_Status = 'OK'
+const OK_STATUS = 'OK'
 
 export default class UnorderedList extends Component {
   constructor(props) {
@@ -22,7 +22,7 @@ export default class UnorderedList extends Component {
       input: prediction     
       }).then((response) => { 
         console.log(response);
-        if(response.data.status == OK_Status)
+        if(response.data.status == OK_STATUS)
         {
           const [searchResult] = response.data.results;
           this.props.onClicked(searchResult);

--- a/client/src/components/SearchResults/index.js
+++ b/client/src/components/SearchResults/index.js
@@ -1,16 +1,44 @@
 import { h, Component } from 'preact';
 import style from './style.css';
+import axios from 'axios';
+import {API_SERVER} from '../../../config';
+const OK_Status = 'OK'
 
 export default class UnorderedList extends Component {
   constructor(props) {
     super(props);
+    this.handleClick = this.handleClick.bind(this);
   }
+
+  /**
+   * On search prediction selection , fetch the geolocation details and 
+   * update the map with a marker on that location
+   *
+   * @param {*} prediction 
+   */
+  handleClick(prediction) {
+    event.preventDefault();
+    axios.post(`${API_SERVER}/map/geocode`, {
+      input: prediction     
+      }).then((response) => { 
+        console.log(response);
+        if(response.data.status == OK_Status)
+        {
+          const [searchResult] = response.data.results;
+          this.props.onClicked(searchResult);
+        }          
+        else
+          alert(response.data.status);
+      
+      });
+    }
+
 
   render() {
     return (
       <ul>
         {this.props.predictions.map((prediction, index) => {
-          return <div key={index} onClick={this.props.onClicked.bind(null,prediction)} >{prediction}</div>
+          return <div key={index} onClick={() => this.handleClick(prediction)} >{prediction}</div>
         })}
       </ul>
     )

--- a/controllers/google-api-controller.js
+++ b/controllers/google-api-controller.js
@@ -415,7 +415,8 @@ exports.geocode = (appReq, appRes) => {
 * @api {POST} /search/textSearch
 * @apiSuccess 200 {JSON} With two root elements:
 * - status: a string identifier of the request outcome
-* - predictions: an array query predictions
+* - results: An array, each element of the results array
+* contains a single result from the specified area (location and radius)
 * @apiError 400 {request error} Google api request error.
 *
 * @param {string} appReq.body.input - The text string on which to search.


### PR DESCRIPTION
Integrate geolocation api and update map with a marker on the location based on user's selction for search prediction.

## Issue:   ##181

## Issue Description:
User clicks on resulting options:
update map to location of selection and add marker at the location

### Summary of solution:
1. Integrated the geolocation api to get location details for selected prediction
2. Update map to set view to the location
3. Only one instance of marker on the map is shown now for search results.

### Can this issue be closed?
No
To Do: 
- Store selected location in state. Should it be mapCenter itself?
- Style search box and other features mentioned in #181

## Have you named your branch in a descriptive way? Remember to name your branch in a unique and descriptive manner in order to properly reflect the issue or feature.
serach-result-selection

### Thanks for contributing!
