### PR TITLE
Utility for frontend to backend requests

### DIFF
--- a/client/src/js/server-requests-utils.js
+++ b/client/src/js/server-requests-utils.js
@@ -5,6 +5,7 @@
 import axios from 'axios';
 import { API_SERVER } from '../../config';
 import { url } from 'inspector';
+import Cookies from "universal-cookie";
 
 /**
 * Configuration of Axios for making server requests
@@ -14,6 +15,8 @@ import { url } from 'inspector';
 const AXIOS_INSTANCE = axios.create({
   baseURL: API_SERVER
 });
+
+const TOKEN_COOKIE = 'token';
 
 /**
  * Key-value pairs for existing base server endpoints
@@ -34,6 +37,26 @@ const BASE_ENDPOINTS = {
 /**
  * Utility functions
  */
+
+const token = {
+  setCookie: val => {
+    const cookies = new Cookies();
+    cookies.set(TOKEN_COOKIE, val, {path: '/'});
+  },
+
+  deleteCookie: () => {
+    const cookies = new Cookies();
+    cookies.remove(TOKEN_COOKIE);
+  },
+
+  get: () => {
+    const cookies = new Cookies();
+    return cookies.get(TOKEN_COOKIE);  
+  }
+
+}
+
+
 exports.postAutocomplete = (input='') => {
   return AXIOS_INSTANCE.post(url=BASE_ENDPOINTS.autocomplete, {input});
 }

--- a/client/src/js/server-requests-utils.js
+++ b/client/src/js/server-requests-utils.js
@@ -34,7 +34,13 @@ const BASE_ENDPOINTS = {
  * Utility functions
  */
 
-const token = {
+
+ /**
+ * Exported functions
+ */
+
+
+export const token = {
   setCookie: val => {
     const cookies = new Cookies();
     cookies.set(TOKEN_COOKIE, val, {path: '/'});
@@ -51,10 +57,6 @@ const token = {
   }
 
 }
-
-/**
- * Exported functions
- */
 
  /* makeRequest(...)
 
@@ -93,7 +95,7 @@ export const makeRequest = (method='GET', baseEndPoint, endPointAddon='', bodyDa
     baseURL: API_SERVER,
     data: bodyData
   }
-
+  
   return axios.request(config);
 }
 

--- a/client/src/js/server-requests-utils.js
+++ b/client/src/js/server-requests-utils.js
@@ -4,7 +4,6 @@
 
 import axios from 'axios';
 import { API_SERVER } from '../../config';
-import { url } from 'inspector';
 import Cookies from "universal-cookie";
 
 /**
@@ -12,9 +11,6 @@ import Cookies from "universal-cookie";
 * See 'Creating an instance' and 'Request Config' sections for more information:
 * https://www.npmjs.com/package/axios
 */
-const AXIOS_INSTANCE = axios.create({
-  baseURL: API_SERVER
-});
 
 const TOKEN_COOKIE = 'token';
 
@@ -49,31 +45,69 @@ const token = {
     cookies.remove(TOKEN_COOKIE);
   },
 
-  get: () => {
+  getCookie: () => {
     const cookies = new Cookies();
     return cookies.get(TOKEN_COOKIE);  
   }
 
 }
 
-
-exports.postAutocomplete = (input='') => {
-  return AXIOS_INSTANCE.post(url=BASE_ENDPOINTS.autocomplete, {input});
-}
-
 /**
  * Exported functions
  */
-// TODO - generalized method
-exports.makeRequest = (method='GET', baseEndPoint, endPointAddon={}, bodyData={}, params={}) => {
-  switch (method) {
-    case 'GET':
-      break;
-    case 'POST':
-      break;
-    case 'DELETE':
-      break;
-    default:
-      return new TypeError(`Invalid request method: ${method}`);
+
+ /* makeRequest(...)
+
+ __include__ import {makeRequest} from "../../js/server-requests-utils"
+ __exmample__  makeRequest('GET','savedPins').then(res => {return res.data})
+
+ __output__ Promise that returns an object with the following keys: 
+    * config 
+    * data: response body
+    * headers
+    * request
+    * status
+    * statusText
+  
+  See: https://www.npmjs.com/package/axios#response-schema for more on the output
+ */
+
+export const makeRequest = (method='GET', baseEndPoint, endPointAddon='', bodyData={}, params={}, headers={}) => {
+
+  const validMethod = ['GET', 'POST', 'DELETE', 'PATCH','PUT']; //determined by axios
+
+  //if it's not a valid method, return rejected promise
+  if (!validMethod.includes(method)) {
+    return new Promise(function (res,rej) {
+      rej(TypeError(`Invalid request method: ${method}`));
+    })
+  } 
+
+  const url = (BASE_ENDPOINTS[baseEndPoint] || baseEndPoint) + endPointAddon;
+  headers['x-access-token'] = token.getCookie();
+
+  let config = {method, 
+    url,
+    params,
+    headers,
+    baseURL: API_SERVER,
+    data: bodyData
   }
+
+  return axios.request(config);
 }
+
+
+/* 
+Incomplete Function...
+
+import { url } from 'inspector';
+
+const AXIOS_INSTANCE = axios.create({
+  baseURL: API_SERVER
+});
+
+exports.postAutocomplete = (input='') => { //ERR: url is read only
+  // return AXIOS_INSTANCE.post(url=BASE_ENDPOINTS.autocomplete, {input});
+}
+ */


### PR DESCRIPTION
## Issue Number: 172

## Issue Description:
Utility needed for handling server requests from the frontend to the backend to aid process for reqeusts and prevent code duplication.

### Summary of solution:
1. Migrate code relevant code from `~client/src/js/utilities.js` to `server-requests-utils.js`
2. Create an object for auth token within `server-requests-utils.js`
3. Create function (`makeRequests`) for request handling via `axios` 
4. Refactor original code in `~client/src/js/utilities.js` to use `server-requests-utils.js`

### Can this issue be closed?
I believe further testing is needed.  Only the routes that were already being used were thoroughly vetted. We will probably need to expand the utility tools in future.

### Should any new issues be added as a result of this solution?
No.

### Have you named your branch in a descriptive way? Remember to name your branch in a unique and descriptive manner in order to properly reflect the issue or feature.
It generally describes the issue but could have been more direct.

### Thanks for contributing!
