### PR TITLE
hotfix: Manifest and client configs

### DIFF
--- a/client/config/dev.config.js
+++ b/client/config/dev.config.js
@@ -1,7 +1,4 @@
-const SECRETS = require('../../config/secrets.json'); // nodejs will auto read json
-
 module.exports = {
-    GOOGLE_API_KEY: SECRETS.google_maps.api_key,
     APP_NAME: 'navi',
     API_SERVER: 'http://localhost:8081',
     REGISTER_PATH: '/users/register',

--- a/client/config/prod.config.js
+++ b/client/config/prod.config.js
@@ -1,6 +1,3 @@
-const SECRETS = require('../../config/secrets.json'); // nodejs will auto read json
-
 module.exports = {
-    GOOGLE_API_KEY: SECRETS.google_maps.api_key,
     APP_NAME: 'navi'
 };

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4336,7 +4336,7 @@
     },
     "eslint-config-airbnb": {
       "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz",
+      "resolved": "https://bcitllc.pkgs.visualstudio.com/_packaging/BcitPackages/npm/registry/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz",
       "integrity": "sha512-zLyOhVWhzB/jwbz7IPSbkUuj7X2ox4PHXTcZkEmDqTvd0baJmJyuxlFPDlZOE/Y5bC+HQRaEkT3FoHo9wIdRiw==",
       "dev": true,
       "requires": {
@@ -5190,7 +5190,7 @@
     },
     "fsevents": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "resolved": "https://bcitllc.pkgs.visualstudio.com/_packaging/BcitPackages/npm/registry/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,

--- a/client/src/manifest.json
+++ b/client/src/manifest.json
@@ -18,11 +18,11 @@
        "src": "client/src/assets/icons/apple-touch-icon.png",
        "sizes": "152x152",
        "type": "image/png"
-     }, , {
+     }, {
        "src": "client/src/assets/icons/favicon-16x16.png",
        "sizes": "128X128",
        "type": "image/png"
-     }, , {
+     }, {
        "src": "client/src/assets/icons/favicon-16x16.png",
        "sizes": "144X144",
        "type": "image/png"


### PR DESCRIPTION
- Error in manifest.json due to extra comma in icons json object structure.

- Remove reference to secrets.json and Googgle api key because not needed
in frontend since server will be handling related requests. Also, to
prevent secrets.json being added into webpack bundle.js. Noticed a few
instances, which may not be related, were secrets.json was being pulled
into dev tools.