### PR TITLE
Updated LeafletOsmMap to remove unSaved markers if a user clicks else…

### DIFF
--- a/client/src/components/LeafletOsmMap/index.js
+++ b/client/src/components/LeafletOsmMap/index.js
@@ -192,8 +192,8 @@ export default class LeafletOSMMap extends Component {
         //remove old icon
         droppedPin.remove()
 
-        //TODO: delete temporary marker from unSavedMarker
-
+        //update unSavedMarker so the saved Marker will show on the map
+        setState({unSavedMarker:null});
         //add a new one
         const savedMarker = makePinMarkers([response.data.pin], L);
         dropPin(savedMarker, event.target);
@@ -229,7 +229,6 @@ export default class LeafletOSMMap extends Component {
 
     L.DomEvent.on(deleteBtn, 'click', function() {
       droppedPin.remove();
-      //TODO: delete temporary marker from unSavedMarker
     });
 
     droppedPin.bindPopup(container);

--- a/client/src/components/LeafletOsmMap/index.js
+++ b/client/src/components/LeafletOsmMap/index.js
@@ -36,7 +36,8 @@ export default class LeafletOSMMap extends Component {
     this.state = {
       map: null,
       mapCenter: null,
-      userMarker: null
+      userMarker: null,
+      unSavedMarker:null //used to track unsaved markers on map
     };
     this.onLocationFound = this.onLocationFound.bind(this);
     this.onLocationError = this.onLocationError.bind(this);
@@ -171,6 +172,13 @@ export default class LeafletOSMMap extends Component {
       autoPan: true
     }).addTo(this.state.map);
 
+    if (this.state.unSavedMarker) {
+          console.log(this.state.unSavedMarker);
+          this.state.unSavedMarker.remove();
+          dropPin(this.state.UnSavedMarker, event.target);
+        }
+    this.setState({ unSavedMarker: droppedPin });
+
     const container = L.DomUtil.create('div');
     const saveBtn = createButton('Save', container);
     const deleteBtn = createButton('Remove', container);
@@ -183,6 +191,8 @@ export default class LeafletOSMMap extends Component {
 
         //remove old icon
         droppedPin.remove()
+
+        //TODO: delete temporary marker from unSavedMarker
 
         //add a new one
         const savedMarker = makePinMarkers([response.data.pin], L);
@@ -213,12 +223,13 @@ export default class LeafletOSMMap extends Component {
           console.log(err); //error saving pin
 
         }
-        
+
       })
     });
 
     L.DomEvent.on(deleteBtn, 'click', function() {
       droppedPin.remove();
+      //TODO: delete temporary marker from unSavedMarker
     });
 
     droppedPin.bindPopup(container);


### PR DESCRIPTION
Issue Number: 226

Issue Description: If you click on multiple points of the map, each location will get a pin without you hitting "save" on the pins. The expected behavior is that one pin will be created, and if you don't hit "save" the pin will be removed when you click elsewhere on the map.

Summary of solution:

Added "unSavedMarker" to components local state to track unsaved markers
When a new marker is created, the old marker is removed
Can this issue be closed?

Additional code needed to clear "unSavedMarker" in the state when a marker is successfully saved, that feature is throwing an error (in Chrome Canary) so testing was not possible

Should any new issues be added as a result of this solution?

Saving a marker throws an error
Uncaught (in promise) TypeError: Failed to fetch xhr.js....